### PR TITLE
Fix train/test split overlap issue

### DIFF
--- a/transformers_multi_label_classification.ipynb
+++ b/transformers_multi_label_classification.ipynb
@@ -448,8 +448,9 @@
     "# Creating the dataset and dataloader for the neural network\n",
     "\n",
     "train_size = 0.8\n",
-    "train_dataset=new_df.sample(frac=train_size,random_state=200).reset_index(drop=True)\n",
+    "train_dataset=new_df.sample(frac=train_size,random_state=200)\n",
     "test_dataset=new_df.drop(train_dataset.index).reset_index(drop=True)\n",
+    "train_dataset = train_dataset.reset_index(drop=True)\n"
     "\n",
     "\n",
     "print(\"FULL Dataset: {}\".format(new_df.shape))\n",


### PR DESCRIPTION
The original indices of `train_dataset` must be dropped *after* we use them to exclude train examples from the test set. Otherwise the current setting trivially excludes the *initial* `train_len` examples from test set, and among the remaining there can still be overlap.