### PR TITLE
Fixed error in category encoding

### DIFF
--- a/transformers_multiclass_classification.ipynb
+++ b/transformers_multiclass_classification.ipynb
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -199,7 +199,7 @@
     "def encode_cat(x):\n",
     "    if x not in encode_dict.keys():\n",
     "        encode_dict[x]=len(encode_dict)\n",
-    "    return len(encode_dict)\n",
+    "    return encode_dict[x]\n",
     "\n",
     "df['ENCODE_CAT'] = df['CATEGORY'].apply(lambda x: encode_cat(x))"
    ]
@@ -735,9 +735,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.7.6 64-bit ('fastai': conda)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python37664bitfastaiconda149f4ca18fae45818735beadf08062d0"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
The encode_cat function would always return the current length of the dictionary instead of the encoding correlating with the input.

Example:
encode_dict['Business'] == 0, but would be stored as 1 in the dataframe, since the len(encode_dict) == 1 in the beginning.