### PR TITLE
Passed truncation to encode_plus method

### DIFF
--- a/transformers_multiclass_classification.ipynb
+++ b/transformers_multiclass_classification.ipynb
@@ -277,6 +277,7 @@
     "            max_length=self.max_len,\n",
     "            pad_to_max_length=True,\n",
     "            return_token_type_ids=True\n",
+    "            truncation=True\n",
     "        )\n",
     "        ids = inputs['input_ids']\n",
     "        mask = inputs['attention_mask']\n",


### PR DESCRIPTION
Fixes the issue similar to the mentioned in [Issue](https://github.com/huggingface/transformers/issues/5397), starting from transformers version v3.0.0.