### PR TITLE
Fixed missing comma

### DIFF
--- a/transformers_multiclass_classification.ipynb
+++ b/transformers_multiclass_classification.ipynb
@@ -276,7 +276,7 @@
     "            add_special_tokens=True,\n",
     "            max_length=self.max_len,\n",
     "            pad_to_max_length=True,\n",
-    "            return_token_type_ids=True\n",
+    "            return_token_type_ids=True,\n",
     "            truncation=True\n",
     "        )\n",
     "        ids = inputs['input_ids']\n",


### PR DESCRIPTION
Fixed missing comma before the last parameter to tokenizer's encode_plus() method.