### PR TITLE
Update transformers_multi_label_classification.ipynb

### DIFF
--- a/transformers_multi_label_classification.ipynb
+++ b/transformers_multi_label_classification.ipynb
@@ -907,7 +907,7 @@
     "class BERTClass(torch.nn.Module):\n",
     "    def __init__(self):\n",
     "        super(BERTClass, self).__init__()\n",
-    "        self.l1 = transformers.BertModel.from_pretrained('bert-base-uncased')\n",
+    "        self.l1 = transformers.BertModel.from_pretrained('bert-base-uncased', return_dict=False)\n",
     "        self.l2 = torch.nn.Dropout(0.3)\n",
     "        self.l3 = torch.nn.Linear(768, 6)\n",
     "    \n",


### PR DESCRIPTION
without `return_dict=False` as an argument, training the model returns the following error:
```
TypeError: linear(): argument 'input' (position 1) must be Tensor, not str
```