### PR TITLE
Update 'train' function in transformers_summarization_wandb.ipynb

### DIFF
--- a/transformers_summarization_wandb.ipynb
+++ b/transformers_summarization_wandb.ipynb
@@ -404,7 +404,7 @@
     "        ids = data['source_ids'].to(device, dtype = torch.long)\n",
     "        mask = data['source_mask'].to(device, dtype = torch.long)\n",
     "\n",
-    "        outputs = model(input_ids = ids, attention_mask = mask, decoder_input_ids=y_ids, lm_labels=lm_labels)\n",
+    "        outputs = model(input_ids = ids, attention_mask = mask, decoder_input_ids=y_ids, labels=lm_labels)\n",
     "        loss = outputs[0]\n",
     "        \n",
     "        if _%10 == 0:\n",


### PR DESCRIPTION
In the 'train' function of transformers_summarization_wandb.ipynb, 'lm_labels' is regarded as parameters. 

However, it doesn't exist. Instead, 'labels' is the correct parameters.

I have tried this when I am finishing my AI related assignment. Would you like to check it?