### PR TITLE
Fix error caused due to new version

### DIFF
--- a/transformers_summarization_wandb.ipynb
+++ b/transformers_summarization_wandb.ipynb
@@ -404,7 +404,7 @@
     "        ids = data['source_ids'].to(device, dtype = torch.long)\n",
     "        mask = data['source_mask'].to(device, dtype = torch.long)\n",
     "\n",
-    "        outputs = model(input_ids = ids, attention_mask = mask, decoder_input_ids=y_ids, lm_labels=lm_labels)\n",
+    "        outputs = model(input_ids = ids, attention_mask = mask, decoder_input_ids=y_ids, labels=labels)\n",
     "        loss = outputs[0]\n",
     "        \n",
     "        if _%10 == 0:\n",


### PR DESCRIPTION
The earlier code was giving error for padding and the reason behind it was the parameter name `lm_labels` as the newer version expects the parameter name to be just `labels`.

Thanks.